### PR TITLE
Add missing command for install option via Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 ```bash
 git clone https://github.com/spryker-community/cli-toolkit && cd cli-toolkit
+composer install
 bin/cli-toolkit
 ```
 


### PR DESCRIPTION
When installing via `git clone` we also need to run `composer install` to install all the packages and generate autoload files needed to run the executable