### PR TITLE
Add ability to specify translator by type via command option for Yves

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ bin/cli-toolkit translation:yves:generate es_ES --working-dir=../b2b-demo-market
 bin/cli-toolkit translation:yves:generate es_ES fr_FR --working-dir=../b2b-demo-marketplace --translation-engine=deepl
 ```
 
+3. Generate missing "category" and "product" translations Yves to Spanish from Spain (es_ES) with default engine.
+```bash
+bin/cli-toolkit translation:yves:generate es_ES --working-dir=../b2b-demo-marketplace --translator=category,product
+```
+
 ### Generate translations for the Spryker Zed backoffice
 
 ```bash

--- a/src/Translator/AbstractYvesTranslator.php
+++ b/src/Translator/AbstractYvesTranslator.php
@@ -187,7 +187,7 @@ abstract class AbstractYvesTranslator
     /**
      * @return string
      */
-    abstract protected function getType(): string;
+    abstract public function getType(): string;
 
     /**
      * @return string

--- a/src/Translator/CategoryTranslator.php
+++ b/src/Translator/CategoryTranslator.php
@@ -14,7 +14,7 @@ class CategoryTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'category';
     }

--- a/src/Translator/CmsBlockTranslator.php
+++ b/src/Translator/CmsBlockTranslator.php
@@ -14,7 +14,7 @@ class CmsBlockTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'cms_block';
     }

--- a/src/Translator/CmsPageTranslator.php
+++ b/src/Translator/CmsPageTranslator.php
@@ -14,7 +14,7 @@ class CmsPageTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'cms_page';
     }

--- a/src/Translator/ContentBannerTranslator.php
+++ b/src/Translator/ContentBannerTranslator.php
@@ -14,7 +14,7 @@ class ContentBannerTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'content_banner';
     }

--- a/src/Translator/GlossaryTranslator.php
+++ b/src/Translator/GlossaryTranslator.php
@@ -110,7 +110,7 @@ class GlossaryTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'glossary';
     }

--- a/src/Translator/MerchantProfileTranslator.php
+++ b/src/Translator/MerchantProfileTranslator.php
@@ -14,7 +14,7 @@ class MerchantProfileTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'merchant_profile';
     }

--- a/src/Translator/NavigationNodeCategoryTranslator.php
+++ b/src/Translator/NavigationNodeCategoryTranslator.php
@@ -14,7 +14,7 @@ class NavigationNodeCategoryTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'navigation_node';
     }

--- a/src/Translator/ProductAbstractTranslator.php
+++ b/src/Translator/ProductAbstractTranslator.php
@@ -14,7 +14,7 @@ class ProductAbstractTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_abstract';
     }

--- a/src/Translator/ProductConcreteTranslator.php
+++ b/src/Translator/ProductConcreteTranslator.php
@@ -14,7 +14,7 @@ class ProductConcreteTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_concrete';
     }

--- a/src/Translator/ProductDiscontinuedTranslator.php
+++ b/src/Translator/ProductDiscontinuedTranslator.php
@@ -14,7 +14,7 @@ class ProductDiscontinuedTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_discontinued';
     }

--- a/src/Translator/ProductLabelTranslator.php
+++ b/src/Translator/ProductLabelTranslator.php
@@ -14,7 +14,7 @@ class ProductLabelTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_label';
     }

--- a/src/Translator/ProductManagementAttributeTranslator.php
+++ b/src/Translator/ProductManagementAttributeTranslator.php
@@ -14,7 +14,7 @@ class ProductManagementAttributeTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_management_attribute';
     }

--- a/src/Translator/ProductOptionTranslator.php
+++ b/src/Translator/ProductOptionTranslator.php
@@ -14,7 +14,7 @@ class ProductOptionTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_option';
     }

--- a/src/Translator/ProductSearchAttributeTranslator.php
+++ b/src/Translator/ProductSearchAttributeTranslator.php
@@ -14,7 +14,7 @@ class ProductSearchAttributeTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_search_attribute';
     }

--- a/src/Translator/ProductSetTranslator.php
+++ b/src/Translator/ProductSetTranslator.php
@@ -14,7 +14,7 @@ class ProductSetTranslator extends AbstractYvesTranslator
     /**
      * @return string
      */
-    protected function getType(): string
+    public function getType(): string
     {
         return 'product_set';
     }


### PR DESCRIPTION
- added `translator` command option for `translation:yves:generate` command
- changed `\SprykerCommunity\CliToolKit\Translator\AbstractYvesTranslator::getType` method visibility to `public`
- added usage example